### PR TITLE
Native share action (MIT-7)

### DIFF
--- a/birdle/static/birdle/daily_bird.js
+++ b/birdle/static/birdle/daily_bird.js
@@ -129,26 +129,32 @@ function updateHint(clippy, popover, hintData) {
 const pluralize = (count, noun, suffix = 'es') => `${count} ${noun}${count !== 1 ? suffix : ''}`;
 
 function showAlert(guessCount, isWinner, emojis, birdData) {
+  const canShare = typeof navigator.share === 'function';
+
   Swal.mixin({
     title: isWinner ? "Congratulations!" : "Oh no!",
     html: isWinner ?
       `You got today's Birdle in ${pluralize(guessCount, 'guess')}.<br>Learn more about the <a href="${birdData.url}" target=_blank>${birdData.name}</a>.` :
       `Today's bird was the <a href="${birdData.url}" target=_blank>${birdData.name}</a>. But don't fret, <a href='https://birdsarentreal.com/' target=_blank>birds aren't real</a> anyway.`,
     icon: isWinner ? "success" : "error",
-    confirmButtonText: "Copy Results",
+    confirmButtonText: canShare ? "Share Results" : "Copy Results",
     showDenyButton: true,
     denyButtonText: "Close"
   }).fire().then((result) => {
     if (result.isConfirmed) {
-      navigator.clipboard.writeText(emojis);
-      Swal.fire({
-        toast: true,
-        title: 'Copied!',
-        icon: "success",
-        showConfirmButton: false,
-        timer: 2000,
-        timerProgressBar: true
-      });
+      if (canShare) {
+        navigator.share({ text: emojis }).catch(() => {});
+      } else {
+        navigator.clipboard.writeText(emojis);
+        Swal.fire({
+          toast: true,
+          title: 'Copied!',
+          icon: "success",
+          showConfirmButton: false,
+          timer: 2000,
+          timerProgressBar: true
+        });
+      }
     }
   });
 }

--- a/birdle/static/birdle/daily_bird.js
+++ b/birdle/static/birdle/daily_bird.js
@@ -139,22 +139,27 @@ function showAlert(guessCount, isWinner, emojis, birdData) {
     icon: isWinner ? "success" : "error",
     confirmButtonText: canShare ? "Share Results" : "Copy Results",
     showDenyButton: true,
-    denyButtonText: "Close"
-  }).fire().then((result) => {
-    if (result.isConfirmed) {
+    denyButtonText: "Close",
+    // Sharing must happen synchronously within the button click, before Swal
+    // starts its close animation, or browsers drop the user-activation
+    // required by navigator.share().
+    preConfirm: () => {
       if (canShare) {
         navigator.share({ text: emojis }).catch(() => {});
       } else {
         navigator.clipboard.writeText(emojis);
-        Swal.fire({
-          toast: true,
-          title: 'Copied!',
-          icon: "success",
-          showConfirmButton: false,
-          timer: 2000,
-          timerProgressBar: true
-        });
       }
+    }
+  }).fire().then((result) => {
+    if (result.isConfirmed && !canShare) {
+      Swal.fire({
+        toast: true,
+        title: 'Copied!',
+        icon: "success",
+        showConfirmButton: false,
+        timer: 2000,
+        timerProgressBar: true
+      });
     }
   });
 }

--- a/birdle/static/birdle/daily_bird.js
+++ b/birdle/static/birdle/daily_bird.js
@@ -129,7 +129,9 @@ function updateHint(clippy, popover, hintData) {
 const pluralize = (count, noun, suffix = 'es') => `${count} ${noun}${count !== 1 ? suffix : ''}`;
 
 function showAlert(guessCount, isWinner, emojis, birdData) {
-  const canShare = typeof navigator.share === 'function';
+  // Native share sheet on mobile, clipboard copy on desktop.
+  const isMobile = /Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+  const canShare = isMobile && typeof navigator.share === 'function';
 
   Swal.mixin({
     title: isWinner ? "Congratulations!" : "Oh no!",


### PR DESCRIPTION
## Summary
- Add a native share action (Web Share API) for sharing daily results in the end-of-game modal
- Falls back to the existing clipboard-copy behavior on browsers/devices without `navigator.share` (mainly desktop)
- Only touches `showAlert` in `daily_bird.js`; no backend changes since the shareable text is already generated server-side

[MIT-7](https://linear.app/birdle/issue/MIT-7)

## Test plan
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `python manage.py test` all pass
- [ ] Manual verification in a real mobile browser / Chrome DevTools device emulation: confirm button reads "Share Results" and opens native share sheet with correct emoji-grid text
- [ ] Manual verification of desktop fallback: button reads "Copy Results", clipboard copy + "Copied!" toast unchanged