### PR TITLE
Best order/family/genus accolades (MIT-15)

### DIFF
--- a/birdle/templates/birdle/stats.html
+++ b/birdle/templates/birdle/stats.html
@@ -16,9 +16,12 @@
         <hr>
         <h3 class="text-center">Accolades</h3>
         <div id="accolades">
-            {% if most_played %}
+            {% if most_played or best %}
             {% for level, accolade in most_played.items %}
             <div>Most Played {{ level|title }}: {{ accolade.name }} ({{ accolade.count }} games)</div>
+            {% endfor %}
+            {% for level, accolade in best.items %}
+            <div>Best {{ level|title }}: {{ accolade.name }} ({{ accolade.win_pct }} win rate)</div>
             {% endfor %}
             {% else %}
             <p class="text-muted">Play a few more games to unlock accolades!</p>

--- a/birdle/templates/birdle/stats.html
+++ b/birdle/templates/birdle/stats.html
@@ -21,7 +21,7 @@
             <div>Most Played {{ level|title }}: {{ accolade.name }} ({{ accolade.count }} games)</div>
             {% endfor %}
             {% for level, accolade in best.items %}
-            <div>Best {{ level|title }}: {{ accolade.name }} ({{ accolade.win_pct }} win rate)</div>
+            <div>Best {{ level|title }}: {{ accolade.name }} ({{ accolade.win_pct }} win rate, {{ accolade.games_won }} games won)</div>
             {% endfor %}
             {% else %}
             <p class="text-muted">Play a few more games to unlock accolades!</p>

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -252,6 +252,7 @@ def stats(request, region_code=None):
 
         taxonomy_stats = get_taxonomy_stats(usergames)
         most_played = get_most_played_accolades(taxonomy_stats)
+        best = get_best_accolades(taxonomy_stats)
 
         stats = {
             "games_played": games_played,
@@ -262,6 +263,7 @@ def stats(request, region_code=None):
             "current_streak": current_streak,
             "best_streak": best_streak,
             "most_played": most_played,
+            "best": best,
         }
     else:
         stats = {
@@ -273,6 +275,7 @@ def stats(request, region_code=None):
             "current_streak": 0,
             "best_streak": 0,
             "most_played": {},
+            "best": {},
         }
     # Render the guess history template with the data
     return render(request, "birdle/stats.html", stats)
@@ -569,6 +572,26 @@ def get_most_played_accolades(taxonomy_stats):
         name = max(eligible, key=lambda name: eligible[name]["played"])
         most_played[level] = {"name": name, "count": eligible[name]["played"]}
     return most_played
+
+
+def get_best_accolades(taxonomy_stats):
+    best = {}
+    for level, taxa in taxonomy_stats.items():
+        eligible = {
+            name: stats for name, stats in taxa.items() if stats["played"] >= MIN_ACCOLADE_GAMES
+        }
+        if not eligible:
+            continue
+        name = max(
+            eligible,
+            key=lambda name: (
+                eligible[name]["won"] / eligible[name]["played"],
+                eligible[name]["played"],
+            ),
+        )
+        win_rate = eligible[name]["won"] / eligible[name]["played"]
+        best[level] = {"name": name, "win_pct": f"{win_rate:.0%}"}
+    return best
 
 
 def error_404(request, exception):

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -590,7 +590,11 @@ def get_best_accolades(taxonomy_stats):
             ),
         )
         win_rate = eligible[name]["won"] / eligible[name]["played"]
-        best[level] = {"name": name, "win_pct": f"{win_rate:.0%}"}
+        best[level] = {
+            "name": name,
+            "win_pct": f"{win_rate:.0%}",
+            "games_won": eligible[name]["won"],
+        }
     return best
 
 


### PR DESCRIPTION
## Summary
- Adds `get_best_accolades(taxonomy_stats)` to `birdle/views.py`, ranking each taxonomy level (order/family/genus) by win rate among taxa with at least `MIN_ACCOLADE_GAMES` played, tie-broken by most games played.
- Wires `best` into both branches of `stats()` and extends the Accolades section of `stats.html` to render a "Best X" line per level, alongside "Most Played".

## Note on scope
MIT-6 (Accolades), which this depends on, had not landed on `origin/mit-6` at implementation time (still `Todo` in Linear). Per this issue's task instructions, `get_taxonomy_stats`, `get_most_played_accolades`, and `MIN_ACCOLADE_GAMES` are stood up here as placeholders matching MIT-6's specified interface, with a comment flagging them for reconciliation once MIT-6's real implementation lands. This branch is based on `mit-7` (rebased onto its real tip) and `mit-6` is still at `origin/main`'s tip, so there's nothing to reconcile against yet.

## Verification
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` all pass.
- `python manage.py test` — no test suite exists in the repo (0 tests found, as before this change).
- Manual: verified empty-state message renders correctly on a fresh session, and `get_best_accolades`/`get_most_played_accolades` produce correct win-rate/played rankings against sample data via the Django shell.
- Reviewed by a fresh `mit-15-reviewer` agent against the diff and AGENTS.md; no findings.

[MIT-15](https://linear.app/birdle/issue/MIT-15)