### PR TITLE
Accolades: Most Played order/family/genus (by region) (MIT-6)

### DIFF
--- a/birdle/templates/birdle/stats.html
+++ b/birdle/templates/birdle/stats.html
@@ -14,6 +14,17 @@
         <div>Best Streak: {{ best_streak }}</div>
         <div>Current Streak: {{ current_streak }}</div>
         <hr>
+        <h3 class="text-center">Accolades</h3>
+        <div id="accolades">
+            {% if most_played %}
+            {% for level, accolade in most_played.items %}
+            <div>Most Played {{ level|title }}: {{ accolade.name }} ({{ accolade.count }} games)</div>
+            {% endfor %}
+            {% else %}
+            <p class="text-muted">Play a few more games to unlock accolades!</p>
+            {% endif %}
+        </div>
+        <hr>
         <h3 class="text-center">Guess Distribution</h3>
         <div class="d-flex justify-content-center" id="guess_dist"></div>
         <hr>

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -186,7 +186,9 @@ def stats(request, region_code=None):
     user_tz = get_user_timezone(request)
     # Retrieve the user's guess history from the database
     if username:
-        usergames = UserGame.objects.filter(user__username=username, game__region__code=region_code)
+        usergames = UserGame.objects.filter(
+            user__username=username, game__region__code=region_code
+        ).select_related("game__bird")
         today = datetime.now(timezone.utc).astimezone(user_tz).date()
         first_game = min([usergame.game.date for usergame in usergames] + [today])
         games = Game.objects.filter(
@@ -248,6 +250,9 @@ def stats(request, region_code=None):
         current_streak = streaks[-1]
         best_streak = max(streaks)
 
+        taxonomy_stats = get_taxonomy_stats(usergames)
+        most_played = get_most_played_accolades(taxonomy_stats)
+
         stats = {
             "games_played": games_played,
             "games_won": games_won,
@@ -256,6 +261,7 @@ def stats(request, region_code=None):
             "history": json.dumps(history),
             "current_streak": current_streak,
             "best_streak": best_streak,
+            "most_played": most_played,
         }
     else:
         stats = {
@@ -266,6 +272,7 @@ def stats(request, region_code=None):
             "history": json.dumps([]),
             "current_streak": 0,
             "best_streak": 0,
+            "most_played": {},
         }
     # Render the guess history template with the data
     return render(request, "birdle/stats.html", stats)
@@ -523,6 +530,45 @@ def build_results_emojis(game, guesses):
     emojis = "\n".join(results)
     link = f"https://www.play-birdle.com/{region.code}/"
     return f"{region.name} Birdle\n{date}\n{emojis}\n{link}"
+
+
+MIN_ACCOLADE_GAMES = 2
+
+
+def get_taxonomy_stats(usergames):
+    # Single pass over usergames so MIT-15 (best), MIT-16 (worst), and MIT-17 (species count)
+    # can all reuse `won`/`species` from the same data instead of re-querying.
+    taxonomy_stats = {
+        "order": {},
+        "family": {},
+        "genus": {},
+    }
+    for usergame in usergames:
+        if usergame.guess_count == 0:
+            continue
+        bird = usergame.game.bird
+        for level, name in (("order", bird.order), ("family", bird.family), ("genus", bird.genus)):
+            entry = taxonomy_stats[level].setdefault(
+                name, {"played": 0, "won": 0, "species": set()}
+            )
+            entry["played"] += 1
+            if usergame.is_winner:
+                entry["won"] += 1
+            entry["species"].add(bird.name)
+    return taxonomy_stats
+
+
+def get_most_played_accolades(taxonomy_stats):
+    most_played = {}
+    for level, taxa in taxonomy_stats.items():
+        eligible = {
+            name: stats for name, stats in taxa.items() if stats["played"] >= MIN_ACCOLADE_GAMES
+        }
+        if not eligible:
+            continue
+        name = max(eligible, key=lambda name: eligible[name]["played"])
+        most_played[level] = {"name": name, "count": eligible[name]["played"]}
+    return most_played
 
 
 def error_404(request, exception):


### PR DESCRIPTION
Adds the shared per-taxon aggregation helper for the Accolades feature (reused by MIT-15/16/17), a new "Accolades" section on the stats page, and one self-contained accolade: "Most Played" order/family/genus, scoped to the currently-selected region.

- `get_taxonomy_stats(usergames)`: single pass over region-scoped `usergames`, tallying `played`/`won`/`species` per order/family/genus (won/species unused here but computed once for MIT-15/16/17 to reuse).
- `get_most_played_accolades(taxonomy_stats)`: picks the most-played taxon per level, requiring `MIN_ACCOLADE_GAMES = 2`.
- New "Accolades" section in `stats.html`, following the existing empty-state convention.

[MIT-6](https://linear.app/mitch-beebe/issue/MIT-6/accolades)

## Verification
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` all pass
- `python manage.py test` (no existing test coverage to extend)
- Manually confirmed empty state renders on `/world/stats/` for an anonymous session, and confirmed the helpers produce correct output against real DB data
- Reviewed by a fresh `mit-6-reviewer` agent against the plan and AGENTS.md — no findings