### PR TITLE
feat: add worst order/family/genus accolade (MIT-16)

### DIFF
--- a/birdle/templates/birdle/stats.html
+++ b/birdle/templates/birdle/stats.html
@@ -24,7 +24,7 @@
             <div>Best {{ level|title }}: {{ accolade.name }} ({{ accolade.win_pct }} win rate, {{ accolade.games_won }} games won)</div>
             {% endfor %}
             {% for level, accolade in worst.items %}
-            <div>Worst {{ level|title }}: {{ accolade.name }} ({{ accolade.win_pct }} win rate)</div>
+            <div>Worst {{ level|title }}: {{ accolade.name }} ({{ accolade.win_pct }} win rate, {{ accolade.games_won }} games won)</div>
             {% endfor %}
             {% else %}
             <p class="text-muted">Play a few more games to unlock accolades!</p>

--- a/birdle/templates/birdle/stats.html
+++ b/birdle/templates/birdle/stats.html
@@ -16,12 +16,15 @@
         <hr>
         <h3 class="text-center">Accolades</h3>
         <div id="accolades">
-            {% if most_played or best %}
+            {% if most_played or best or worst %}
             {% for level, accolade in most_played.items %}
             <div>Most Played {{ level|title }}: {{ accolade.name }} ({{ accolade.count }} games)</div>
             {% endfor %}
             {% for level, accolade in best.items %}
             <div>Best {{ level|title }}: {{ accolade.name }} ({{ accolade.win_pct }} win rate, {{ accolade.games_won }} games won)</div>
+            {% endfor %}
+            {% for level, accolade in worst.items %}
+            <div>Worst {{ level|title }}: {{ accolade.name }} ({{ accolade.win_pct }} win rate)</div>
             {% endfor %}
             {% else %}
             <p class="text-muted">Play a few more games to unlock accolades!</p>

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -617,7 +617,11 @@ def get_worst_accolades(taxonomy_stats):
             ),
         )
         win_rate = eligible[name]["won"] / eligible[name]["played"]
-        worst[level] = {"name": name, "win_pct": f"{win_rate:.0%}"}
+        worst[level] = {
+            "name": name,
+            "win_pct": f"{win_rate:.0%}",
+            "games_won": eligible[name]["won"],
+        }
     return worst
 
 

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -253,6 +253,7 @@ def stats(request, region_code=None):
         taxonomy_stats = get_taxonomy_stats(usergames)
         most_played = get_most_played_accolades(taxonomy_stats)
         best = get_best_accolades(taxonomy_stats)
+        worst = get_worst_accolades(taxonomy_stats)
 
         stats = {
             "games_played": games_played,
@@ -264,6 +265,7 @@ def stats(request, region_code=None):
             "best_streak": best_streak,
             "most_played": most_played,
             "best": best,
+            "worst": worst,
         }
     else:
         stats = {
@@ -276,6 +278,7 @@ def stats(request, region_code=None):
             "best_streak": 0,
             "most_played": {},
             "best": {},
+            "worst": {},
         }
     # Render the guess history template with the data
     return render(request, "birdle/stats.html", stats)
@@ -596,6 +599,26 @@ def get_best_accolades(taxonomy_stats):
             "games_won": eligible[name]["won"],
         }
     return best
+
+
+def get_worst_accolades(taxonomy_stats):
+    worst = {}
+    for level, taxa in taxonomy_stats.items():
+        eligible = {
+            name: stats for name, stats in taxa.items() if stats["played"] >= MIN_ACCOLADE_GAMES
+        }
+        if not eligible:
+            continue
+        name = min(
+            eligible,
+            key=lambda name: (
+                eligible[name]["won"] / eligible[name]["played"],
+                -eligible[name]["played"],
+            ),
+        )
+        win_rate = eligible[name]["won"] / eligible[name]["played"]
+        worst[level] = {"name": name, "win_pct": f"{win_rate:.0%}"}
+    return worst
 
 
 def error_404(request, exception):


### PR DESCRIPTION
## Summary
Sub-issue of MIT-6 (Accolades). Mirrors MIT-15's "Best" accolade: surfaces the order/family/genus
the user has the *lowest* win rate in (region-scoped), among taxa with at least
`MIN_ACCOLADE_GAMES` completed games, tie-broken by *most* games played.

## Changes
- `birdle/views.py`: add `get_worst_accolades(taxonomy_stats)`, mirroring `get_best_accolades`
  but picking the lowest win rate (tie-broken by most games played). Wire `worst` into `stats()`
  for both the authenticated and anonymous branches.
- `birdle/templates/birdle/stats.html`: extend the Accolades block's `{% if %}` condition and add
  a "Worst" loop alongside "Most Played" and "Best".

## Verification
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` all pass.
- `python manage.py test` — no tests exist in this repo yet.
- Manually verified `get_worst_accolades`/`get_best_accolades` output and template rendering via
  a scripted Django shell/template render (deliberately mismatched win rates across taxa) to
  confirm the "Worst" line renders distinctly from "Best"/"Most Played".

[MIT-16](https://linear.app/mitch-beebe/issue/MIT-16/worst-orderfamilygenus)