### PR TITLE
feat: add species identified per order/family/genus accolade (MIT-17)

### DIFF
--- a/birdle/templates/birdle/stats.html
+++ b/birdle/templates/birdle/stats.html
@@ -16,7 +16,7 @@
         <hr>
         <h3 class="text-center">Accolades</h3>
         <div id="accolades">
-            {% if most_played or best or worst %}
+            {% if most_played or best or worst or species_identified %}
             {% for level, accolade in most_played.items %}
             <div>Most Played {{ level|title }}: {{ accolade.name }} ({{ accolade.count }} games)</div>
             {% endfor %}
@@ -25,6 +25,14 @@
             {% endfor %}
             {% for level, accolade in worst.items %}
             <div>Worst {{ level|title }}: {{ accolade.name }} ({{ accolade.win_pct }} win rate, {{ accolade.games_won }} games won)</div>
+            {% endfor %}
+            {% for level, taxa in species_identified.items %}
+            {% if taxa %}
+            <div class="mt-2"><strong>Species Identified by {{ level|title }}</strong></div>
+            {% for name, count in taxa %}
+            <div>{{ name }}: {{ count }}</div>
+            {% endfor %}
+            {% endif %}
             {% endfor %}
             {% else %}
             <p class="text-muted">Play a few more games to unlock accolades!</p>

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -254,6 +254,7 @@ def stats(request, region_code=None):
         most_played = get_most_played_accolades(taxonomy_stats)
         best = get_best_accolades(taxonomy_stats)
         worst = get_worst_accolades(taxonomy_stats)
+        species_identified = get_species_identified(taxonomy_stats)
 
         stats = {
             "games_played": games_played,
@@ -266,6 +267,7 @@ def stats(request, region_code=None):
             "most_played": most_played,
             "best": best,
             "worst": worst,
+            "species_identified": species_identified,
         }
     else:
         stats = {
@@ -279,6 +281,7 @@ def stats(request, region_code=None):
             "most_played": {},
             "best": {},
             "worst": {},
+            "species_identified": {},
         }
     # Render the guess history template with the data
     return render(request, "birdle/stats.html", stats)
@@ -555,11 +558,12 @@ def get_taxonomy_stats(usergames):
         bird = usergame.game.bird
         for level, name in (("order", bird.order), ("family", bird.family), ("genus", bird.genus)):
             entry = taxonomy_stats[level].setdefault(
-                name, {"played": 0, "won": 0, "species": set()}
+                name, {"played": 0, "won": 0, "species": set(), "species_won": set()}
             )
             entry["played"] += 1
             if usergame.is_winner:
                 entry["won"] += 1
+                entry["species_won"].add(bird.name)
             entry["species"].add(bird.name)
     return taxonomy_stats
 
@@ -623,6 +627,20 @@ def get_worst_accolades(taxonomy_stats):
             "games_won": eligible[name]["won"],
         }
     return worst
+
+
+def get_species_identified(taxonomy_stats, limit=5):
+    # For each taxonomy level, the top `limit` taxa by count of distinct species won,
+    # sorted descending. No MIN_ACCOLADE_GAMES threshold: a single correctly-identified
+    # species is a countable fact regardless of sample size.
+    species_identified = {}
+    for level, taxa in taxonomy_stats.items():
+        counts = [
+            (name, len(data["species_won"])) for name, data in taxa.items() if data["species_won"]
+        ]
+        counts.sort(key=lambda item: item[1], reverse=True)
+        species_identified[level] = counts[:limit]
+    return species_identified
 
 
 def error_404(request, exception):


### PR DESCRIPTION
## Summary
Adds a "Species Identified by Order/Family/Genus" accolade to the stats page: for each taxonomy level, the top 5 taxa by count of distinct species the user has actually won a game for, sorted descending. No minimum-games threshold, unlike Most Played/Best/Worst — a single correctly-identified species is a real, countable fact regardless of sample size.

## Changes
- `birdle/views.py`: added `get_species_identified(taxonomy_stats, limit=5)`, wired into `stats()` alongside the existing `most_played`/`best`/`worst` accolades.
- `birdle/templates/birdle/stats.html`: extended the existing `#accolades` block's guard to `{% if most_played or best or worst or species_identified %}` and added a species-identified loop after the Worst loop.

### Fix to inherited MIT-6 code
MIT-6's `get_taxonomy_stats` populates its `species` set for every *played* game regardless of win/loss, but this accolade needs distinct species actually *won*. Added a second `species_won` set alongside `species` in `get_taxonomy_stats`, populated only inside the `is_winner` branch — `species` itself and its other consumers (`get_most_played_accolades`) are untouched. Caught by review before landing.

## Test plan
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check`, `python manage.py test` all pass.
- Reviewed by a fresh agent against the plan and AGENTS.md (2 rounds, 0 findings on final pass).
- Manual verification pending: visit `/world/stats/` after winning several games across distinct species in the same taxon.

[MIT-17](https://linear.app/mitch-beebe/issue/MIT-17/of-species-idd-per-orderfamilygenus)