### PR TITLE
feat: add World Traveler accolade (MIT-71)

### DIFF
--- a/birdle/templates/birdle/stats.html
+++ b/birdle/templates/birdle/stats.html
@@ -16,7 +16,7 @@
         <hr>
         <h3 class="text-center">Accolades</h3>
         <div id="accolades">
-            {% if most_played or best or worst or species_identified %}
+            {% if most_played or best or worst or species_identified or world_traveler.earned %}
             {% for level, accolade in most_played.items %}
             <div>Most Played {{ level|title }}: {{ accolade.name }} ({{ accolade.count }} games)</div>
             {% endfor %}
@@ -34,6 +34,9 @@
             {% endfor %}
             {% endif %}
             {% endfor %}
+            {% if world_traveler.earned %}
+            <div class="mt-2">🌎 <strong>World Traveler</strong>: won every region in a single day ({{ world_traveler.count }} time{{ world_traveler.count|pluralize }}, latest {{ world_traveler.latest }})</div>
+            {% endif %}
             {% else %}
             <p class="text-muted">Play a few more games to unlock accolades!</p>
             {% endif %}

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -255,6 +255,7 @@ def stats(request, region_code=None):
         best = get_best_accolades(taxonomy_stats)
         worst = get_worst_accolades(taxonomy_stats)
         species_identified = get_species_identified(taxonomy_stats)
+        world_traveler = get_world_traveler_status(username)
 
         stats = {
             "games_played": games_played,
@@ -268,6 +269,7 @@ def stats(request, region_code=None):
             "best": best,
             "worst": worst,
             "species_identified": species_identified,
+            "world_traveler": world_traveler,
         }
     else:
         stats = {
@@ -282,6 +284,7 @@ def stats(request, region_code=None):
             "best": {},
             "worst": {},
             "species_identified": {},
+            "world_traveler": {"earned": False, "count": 0, "latest": None},
         }
     # Render the guess history template with the data
     return render(request, "birdle/stats.html", stats)
@@ -627,6 +630,24 @@ def get_worst_accolades(taxonomy_stats):
             "games_won": eligible[name]["won"],
         }
     return worst
+
+
+def get_world_traveler_status(username):
+    # Not region-scoped (see MIT-6): spans every region, so query across all of them.
+    usergames = UserGame.objects.filter(user__username=username).select_related("game__region")
+    wins_by_date = {}
+    for usergame in usergames:
+        if usergame.is_winner:
+            wins_by_date.setdefault(usergame.game.date, set()).add(usergame.game.region.code)
+    all_regions = set(get_regions().keys())
+    achieved_dates = sorted(
+        date for date, regions in wins_by_date.items() if all_regions <= regions
+    )
+    return {
+        "earned": bool(achieved_dates),
+        "count": len(achieved_dates),
+        "latest": achieved_dates[-1] if achieved_dates else None,
+    }
 
 
 def get_species_identified(taxonomy_stats, limit=5):


### PR DESCRIPTION
## Summary
- Adds a "World Traveler" accolade: earned when a user wins a game in every region on the same calendar date.
- Per [MIT-6](https://linear.app/mitch-beebe/issue/MIT-6)'s guidance, this achievement is explicitly not region-scoped (unlike Best/Worst/Most Played/Species Identified) — it's computed once, independent of the currently-selected region, and shown on every region's stats page.

## Changes
- `birdle/views.py`: new `get_world_traveler_status(username)` helper, following the existing accolade-helper conventions; wired into `stats()` for both the logged-in and anonymous branches.
- `birdle/templates/birdle/stats.html`: extends the Accolades guard and renders the new badge when earned.

## Test plan
- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check` all pass
- [x] Manually verified via Django shell: creating winning `Game`/`UserGame`/`Guess` rows across all 9 regions on the same date yields `earned: True`; leaving one region unwon yields `earned: False`
- [x] Reviewed by a fresh `mit-71-reviewer` agent against this plan and AGENTS.md — no findings

[MIT-71](https://linear.app/mitch-beebe/issue/MIT-71/world-traveler-achievementbadge)