### PR TITLE
perf: fix N+1 queries and cache taxon totals on /stats page (MIT-20)

### DIFF
--- a/birdle/models.py
+++ b/birdle/models.py
@@ -1,4 +1,5 @@
 import random
+from typing import TYPE_CHECKING
 from django.db import models
 from django.conf import settings
 
@@ -89,6 +90,13 @@ class Game(models.Model):
 class UserGame(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     game = models.ForeignKey(Game, on_delete=models.CASCADE)
+
+    if TYPE_CHECKING:
+        # Annotated dynamically via .annotate() in birdle/views.py for stats queries
+        # (num_guesses/has_won), to avoid the N+1 queries the guess_count/is_winner
+        # properties below would otherwise cause.
+        num_guesses: int
+        has_won: bool
 
     def __str__(self):
         return f"{self.game.date}: {self.user}"

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -148,7 +148,11 @@ def daily_bird(request, region_code=None):
                 bird=guess,
                 hint_used=request.POST.get("hint_used") == "true",
             )
-            cache.delete(_stats_cache_key(user.username, region_code))
+            # Invalidate every region's cached stats for this user, not just the
+            # current one: world_traveler is cross-region (see MIT-6), so a win in
+            # one region can change the cached stats of every other region too.
+            for other_region_code in get_regions():
+                cache.delete(_stats_cache_key(user.username, other_region_code))
 
         # Get all user guesses
         guesses = Guess.objects.filter(usergame=usergame).order_by("guessed_at")

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -9,7 +9,8 @@ from urllib.parse import quote, unquote, urlparse
 from django.contrib.auth.models import User
 from .models import Bird, Guess, Game, UserGame, Image, BirdRegion, Region
 from .forms import BirdRegionForm
-from django.db.models import Count, Q
+from django.core.cache import cache
+from django.db.models import Count, Exists, OuterRef, Q
 from django.http import Http404, HttpResponse, JsonResponse
 from django.template.loader import render_to_string
 from django.template.defaulttags import register
@@ -186,9 +187,16 @@ def stats(request, region_code=None):
     user_tz = get_user_timezone(request)
     # Retrieve the user's guess history from the database
     if username:
-        usergames = UserGame.objects.filter(
-            user__username=username, game__region__code=region_code
-        ).select_related("game__bird")
+        usergames = (
+            UserGame.objects.filter(user__username=username, game__region__code=region_code)
+            .select_related("game__bird")
+            .annotate(
+                num_guesses=Count("guess"),
+                has_won=Exists(
+                    Guess.objects.filter(usergame=OuterRef("pk"), bird=OuterRef("game__bird"))
+                ),
+            )
+        )
         today = datetime.now(timezone.utc).astimezone(user_tz).date()
         first_game = min([usergame.game.date for usergame in usergames] + [today])
         games = Game.objects.filter(
@@ -196,17 +204,17 @@ def stats(request, region_code=None):
         ).order_by("date")
 
         # User stats
-        games_played = len([game for game in usergames if game.guess_count > 0])
-        wins = [game for game in usergames if game.is_winner]
+        games_played = len([game for game in usergames if game.num_guesses > 0])
+        wins = [game for game in usergames if game.has_won]
         games_won = len(wins)
         win_pct = games_won / games_played if games_played > 0 else 0
-        guess_counts = [game.guess_count for game in wins if game.guess_count > 0]
+        guess_counts = [game.num_guesses for game in wins if game.num_guesses > 0]
         guess_dist = [{"guesses": i, "count": guess_counts.count(i)} for i in range(1, 7)]
 
         def result(game):
-            if game.guess_count == 0:
+            if game.num_guesses == 0:
                 result = "Did not play"
-            elif game.is_winner:
+            elif game.has_won:
                 result = "Win"
             else:
                 result = "Loss"
@@ -231,7 +239,7 @@ def stats(request, region_code=None):
         if todays_result:
             history = (
                 history[0:-1]
-                if todays_result[0].guess_count < 6 and not todays_result[0].is_winner
+                if todays_result[0].num_guesses < 6 and not todays_result[0].has_won
                 else history
             )
         else:
@@ -559,7 +567,7 @@ def get_taxonomy_stats(usergames):
         "genus": {},
     }
     for usergame in usergames:
-        if usergame.guess_count == 0:
+        if usergame.num_guesses == 0:
             continue
         bird = usergame.game.bird
         for level, name in (("order", bird.order), ("family", bird.family), ("genus", bird.genus)):
@@ -567,7 +575,7 @@ def get_taxonomy_stats(usergames):
                 name, {"played": 0, "won": 0, "species": set(), "species_won": set()}
             )
             entry["played"] += 1
-            if usergame.is_winner:
+            if usergame.has_won:
                 entry["won"] += 1
                 entry["species_won"].add(bird.name)
             entry["species"].add(bird.name)
@@ -637,10 +645,18 @@ def get_worst_accolades(taxonomy_stats):
 
 def get_world_traveler_status(username):
     # Not region-scoped (see MIT-6): spans every region, so query across all of them.
-    usergames = UserGame.objects.filter(user__username=username).select_related("game__region")
+    usergames = (
+        UserGame.objects.filter(user__username=username)
+        .select_related("game__region")
+        .annotate(
+            has_won=Exists(
+                Guess.objects.filter(usergame=OuterRef("pk"), bird=OuterRef("game__bird"))
+            )
+        )
+    )
     wins_by_date = {}
     for usergame in usergames:
-        if usergame.is_winner:
+        if usergame.has_won:
             wins_by_date.setdefault(usergame.game.date, set()).add(usergame.game.region.code)
     all_regions = set(get_regions().keys())
     achieved_dates = sorted(
@@ -672,12 +688,20 @@ CATCH_EM_ALL_TIERS = [(1.0, "Bird"), (0.75, "Chick"), (0.5, "Hatchling")]
 
 def get_taxon_species_totals(region_code, level):
     # Total distinct species per taxon name, among birds available in this region.
-    rows = (
-        Bird.objects.filter(birdregion__region__code=region_code)
-        .values(level)
-        .annotate(total=Count("species_code", distinct=True))
-    )
-    return {row[level]: row["total"] for row in rows}
+    # Cached: this is static reference data that only changes via management commands
+    # (import_bird_species, update_birdregions). Cache must be cleared manually (or the
+    # TTL shortened) if that data changes and stats should reflect it immediately.
+    cache_key = f"taxon_species_totals:{region_code}:{level}"
+    totals = cache.get(cache_key)
+    if totals is None:
+        rows = (
+            Bird.objects.filter(birdregion__region__code=region_code)
+            .values(level)
+            .annotate(total=Count("species_code", distinct=True))
+        )
+        totals = {row[level]: row["total"] for row in rows}
+        cache.set(cache_key, totals, timeout=60 * 60 * 24)
+    return totals
 
 
 def get_catch_em_all_progress(taxonomy_stats, region_code):

--- a/birdle/views.py
+++ b/birdle/views.py
@@ -64,6 +64,10 @@ def todays_game(region_code="world", tz=None):
     return game
 
 
+def _stats_cache_key(username, region_code):
+    return f"stats:{username}:{region_code}"
+
+
 def daily_bird(request, region_code=None):
     # Redirect to regional URL if no region code provided
     if not region_code:
@@ -144,6 +148,7 @@ def daily_bird(request, region_code=None):
                 bird=guess,
                 hint_used=request.POST.get("hint_used") == "true",
             )
+            cache.delete(_stats_cache_key(user.username, region_code))
 
         # Get all user guesses
         guesses = Guess.objects.filter(usergame=usergame).order_by("guessed_at")
@@ -185,8 +190,10 @@ def stats(request, region_code=None):
 
     username = request.session.get("username")
     user_tz = get_user_timezone(request)
+    cache_key = _stats_cache_key(username, region_code) if username else None
+    stats = cache.get(cache_key) if cache_key else None
     # Retrieve the user's guess history from the database
-    if username:
+    if username and stats is None:
         usergames = (
             UserGame.objects.filter(user__username=username, game__region__code=region_code)
             .select_related("game__bird")
@@ -281,7 +288,8 @@ def stats(request, region_code=None):
             "world_traveler": world_traveler,
             "catch_em_all": catch_em_all,
         }
-    else:
+        cache.set(cache_key, stats, timeout=60 * 10)
+    elif not username:
         stats = {
             "games_played": 0,
             "games_won": 0,


### PR DESCRIPTION
## Summary
- Annotate the `usergames` queryset in `stats()` with `num_guesses`/`has_won` (single query via `Count`/`Exists`) instead of hitting the `UserGame.guess_count`/`is_winner` properties repeatedly (each triggers a fresh DB query) across multiple passes over the same data.
- Apply the same annotation approach in `get_taxonomy_stats()` and `get_world_traveler_status()`, which had the same N+1 pattern.
- Cache `get_taxon_species_totals()` (static-ish reference data, only changes via `import_bird_species`/`update_birdregions` management commands) in Django's default `LocMemCache` with a 24h TTL.
- Cache the computed per-user `stats` dict itself, keyed by `stats:{username}:{region_code}`, with a 10-minute safety-net timeout. Invalidated on write: `daily_bird()`'s POST handler deletes the cached stats for **every** region (not just the current one) right after a `Guess` is created, since `world_traveler` is cross-region (see MIT-6) and a win in one region can change what every other region's cached stats should show.
- Add `TYPE_CHECKING`-guarded `num_guesses`/`has_won` attribute declarations to `UserGame` in `models.py` so `ty` understands the dynamically-annotated fields.

`UserGame.guess_count`/`is_winner` properties themselves are untouched — they're still used correctly elsewhere (e.g. `daily_bird` view, single-object context where N+1 isn't a concern).

## Verification
- For a user with 436 games played, query count for the full stats computation (games_played/wins/taxonomy_stats/most_played/best/worst/species_identified/world_traveler/catch_em_all) dropped from 9000+ (capped by Django's query-log limit) to 4 on a cache miss, and to 0 (function-level) on a cache hit.
- Confirmed identical output (most_played/best/worst/species_identified/world_traveler) before and after the N+1 change for that user.
- Manually verified stats cache correctness: cache hit returns identical data to a fresh computation; a guess submission invalidates the cache (confirmed via `daily_bird()`); a cross-region win invalidates every region's cached stats, not just the submitted region's.
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` all pass.
- No existing tests in `birdle/tests.py` to run against this module.
- Reviewed in two rounds by a fresh `mit-20-reviewer` agent against the plan and AGENTS.md — one real finding (cross-region World Traveler staleness) was raised and fixed; no further findings after the fix.

## Note
The cache key for `get_taxon_species_totals` would need manual clearing (or a shorter TTL) if bird/region reference data is updated and should reflect immediately — no invalidation hooks were added, per scope (24h TTL on rarely-changing data).

[MIT-20](https://linear.app/mitch-beebe/issue/MIT-20/speed-up-stats-page)